### PR TITLE
Sort translation messages by key using json-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "i18n"
   ],
   "author": "Gertjan Reynaert <gertjan.reynaert@gmail.com>",
+  "contributors": [
+    "Bart van Andel <bavanandel@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/GertjanReynaert/react-intl-translations-manager/issues"
@@ -35,6 +38,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "glob": "^7.0.3",
+    "json-stable-stringify": "^1.0.1",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {

--- a/src/compareByKey.js
+++ b/src/compareByKey.js
@@ -1,0 +1,4 @@
+export default function compareByKey(a, b) {
+  var ka = a.key, kb = b.key;
+  return ka < kb ? -1 : ka > kb ? 1 : 0;
+}

--- a/src/compareByKey.js
+++ b/src/compareByKey.js
@@ -1,4 +1,12 @@
-export default function compareByKey(a, b) {
-  var ka = a.key, kb = b.key;
-  return ka < kb ? -1 : ka > kb ? 1 : 0;
-}
+export default (a, b) => {
+  const ka = a.key;
+  const kb = b.key;
+
+  if (ka < kb) {
+    return -1;
+  }
+  if (ka > kb) {
+    return 1;
+  }
+  return 0;
+};

--- a/src/createSingleMessagesFile.js
+++ b/src/createSingleMessagesFile.js
@@ -1,5 +1,6 @@
 import Path from 'path';
 import { writeFileSync } from 'fs';
+import stringify from 'json-stable-stringify';
 
 export default ({
   messages,
@@ -15,5 +16,5 @@ export default ({
 
   const DIR = Path.join(directory, fileName);
 
-  writeFileSync(DIR, JSON.stringify(messages, null, jsonSpaceIndentation));
+  writeFileSync(DIR, stringify(messages, {space: jsonSpaceIndentation}));
 };

--- a/src/createSingleMessagesFile.js
+++ b/src/createSingleMessagesFile.js
@@ -6,16 +6,21 @@ export default ({
   messages,
   directory,
   fileName = 'defaultMessages.json',
-  sortObjectsByKey = false,
+  sortKeys = true,
   jsonSpaceIndentation = 2,
 }) => {
-  if (!messages)
+  if (!messages) {
     throw new Error('Messages are required');
+  }
 
-  if (!directory || typeof directory !== 'string' || directory.length === 0)
+  if (!directory || typeof directory !== 'string' || directory.length === 0) {
     throw new Error('Directory is required');
+  }
 
   const DIR = Path.join(directory, fileName);
 
-  writeFileSync(DIR, stringify(messages, {space: jsonSpaceIndentation, sortKeys: sortObjectsByKey}));
+  writeFileSync(
+    DIR,
+    stringify(messages, { space: jsonSpaceIndentation, sortKeys })
+  );
 };

--- a/src/createSingleMessagesFile.js
+++ b/src/createSingleMessagesFile.js
@@ -1,20 +1,21 @@
 import Path from 'path';
 import { writeFileSync } from 'fs';
-import stringify from 'json-stable-stringify';
+import stringify from './stringify';
 
 export default ({
   messages,
   directory,
   fileName = 'defaultMessages.json',
+  sortObjectsByKey = false,
   jsonSpaceIndentation = 2,
 }) => {
-  if (!messages) throw new Error('Messages are required');
+  if (!messages)
+    throw new Error('Messages are required');
 
-  if (!directory || typeof directory !== 'string' || directory.length === 0) {
+  if (!directory || typeof directory !== 'string' || directory.length === 0)
     throw new Error('Directory is required');
-  }
 
   const DIR = Path.join(directory, fileName);
 
-  writeFileSync(DIR, stringify(messages, {space: jsonSpaceIndentation}));
+  writeFileSync(DIR, stringify(messages, {space: jsonSpaceIndentation, sortKeys: sortObjectsByKey}));
 };

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -19,19 +19,18 @@ export default ({
   languages = [],
   singleMessagesFile = false,
   detectDuplicateIds = true,
-  sortObjectsByKey = false,
+  sortKeys = true,
   printers = {},
   jsonSpaceIndentation = 2,
 }) => {
   if (!messagesDirectory || !translationsDirectory) {
     throw new Error('messagesDirectory and translationsDirectory are required');
   }
-  
-  var stringifyOpts = {
-    space: jsonSpaceIndentation,
-    sortKeys: sortObjectsByKey
-  };
 
+  const stringifyOpts = {
+    space: jsonSpaceIndentation,
+    sortKeys,
+  };
   core(languages, {
     provideExtractedMessages: () => readMessageFiles(messagesDirectory),
     outputSingleFile: combinedFiles => {
@@ -39,7 +38,7 @@ export default ({
         createSingleMessagesFile({
           messages: combinedFiles,
           directory: translationsDirectory,
-          sortObjectsByKey
+          sortKeys,
         });
       }
     },
@@ -94,7 +93,7 @@ export default ({
           printers.printLanguageReport(langResults.languageFilename, langResults.report);
         } else {
           header(`Maintaining ${yellow(langResults.languageFilename)}:`);
-          printResults({...langResults.report, sortObjectsByKey});
+          printResults({ ...langResults.report, sortKeys });
         }
 
         writeFileSync(

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -2,6 +2,7 @@ import { writeFileSync } from 'fs';
 import { sync as mkdirpSync } from 'mkdirp';
 import Path from 'path';
 import { yellow, red, green } from 'chalk';
+import stringify from 'json-stable-stringify';
 
 import readFile from './readFile';
 import { header, subheader, footer } from './printer';
@@ -90,11 +91,11 @@ export default ({
 
         writeFileSync(
           langResults.languageFilepath,
-          JSON.stringify(langResults.report.fileOutput, null, 2)
+          stringify(langResults.report.fileOutput, {space: 2})
         );
         writeFileSync(
           langResults.whitelistFilepath,
-          JSON.stringify(langResults.report.whitelistOutput, null, 2)
+          stringify(langResults.report.whitelistOutput, {space: 2})
         );
       } else {
         if (langResults.report.noTranslationFile) {
@@ -106,7 +107,7 @@ export default ({
               A new one is created.
             ```);
           }
-          writeFileSync(langResults, JSON.stringify(langResults.report.fileOutput, null, 2));
+          writeFileSync(langResults, stringify(langResults.report.fileOutput, {space: 2}));
         }
 
         if (langResults.report.noWhitelistFile) {
@@ -118,7 +119,7 @@ export default ({
               A new one is created.
             ```);
           }
-          writeFileSync(langResults.whitelistFilepath, JSON.stringify([], null, 2));
+          writeFileSync(langResults.whitelistFilepath, stringify([], {space: 2}));
         }
       }
     },

--- a/src/printResults.js
+++ b/src/printResults.js
@@ -7,33 +7,30 @@ export default ({
   deleted,
   untranslated,
   added,
-  sortObjectsByKey = false,
-}) => {console.log("Sort? ", sortObjectsByKey);
+  sortKeys = true,
+}) => {
   if (!(deleted.length || added.length || untranslated.length)) {
     console.log(green('  Perfectly maintained, no remarks!'));
     newLine();
   } else {
     if (deleted.length) {
-      if (sortObjectsByKey)
-        deleted = deleted.sort(compareByKey);
+      const items = sortKeys ? deleted.sort(compareByKey) : deleted;
       subheader('Deleted keys:');
-      deleted.forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
+      items.forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (untranslated.length) {
-      if (sortObjectsByKey)
-        untranslated = untranslated.sort(compareByKey);
+      const items = sortKeys ? untranslated.sort(compareByKey) : untranslated;
       subheader('Untranslated keys:');
-      untranslated.forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
+      items.forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (added.length) {
-      if (sortObjectsByKey)
-        added = added.sort(compareByKey);
+      const items = sortKeys ? added.sort(compareByKey) : added;
       subheader('Added keys:');
-      added.forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
+      items.forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
       newLine();
     }
   }

--- a/src/printResults.js
+++ b/src/printResults.js
@@ -1,36 +1,39 @@
 import { green, yellow, red, cyan } from 'chalk';
 
 import { newLine, subheader } from './printer';
-
-function sortByKey(a, b) {
-  var ka = a.key, kb = b.key;
-  return ka < kb ? -1 : ka > kb ? 1 : 0;
-}
+import compareByKey from './compareByKey';
 
 export default ({
   deleted,
   untranslated,
   added,
-}) => {
+  sortObjectsByKey = false,
+}) => {console.log("Sort? ", sortObjectsByKey);
   if (!(deleted.length || added.length || untranslated.length)) {
     console.log(green('  Perfectly maintained, no remarks!'));
     newLine();
   } else {
     if (deleted.length) {
+      if (sortObjectsByKey)
+        deleted = deleted.sort(compareByKey);
       subheader('Deleted keys:');
-      deleted.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
+      deleted.forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (untranslated.length) {
+      if (sortObjectsByKey)
+        untranslated = untranslated.sort(compareByKey);
       subheader('Untranslated keys:');
-      untranslated.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
+      untranslated.forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (added.length) {
+      if (sortObjectsByKey)
+        added = added.sort(compareByKey);
       subheader('Added keys:');
-      added.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
+      added.forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
       newLine();
     }
   }

--- a/src/printResults.js
+++ b/src/printResults.js
@@ -2,6 +2,11 @@ import { green, yellow, red, cyan } from 'chalk';
 
 import { newLine, subheader } from './printer';
 
+function sortByKey(a, b) {
+  var ka = a.key, kb = b.key;
+  return ka < kb ? -1 : ka > kb ? 1 : 0;
+}
+
 export default ({
   deleted,
   untranslated,
@@ -13,19 +18,19 @@ export default ({
   } else {
     if (deleted.length) {
       subheader('Deleted keys:');
-      deleted.forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
+      deleted.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${red(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (untranslated.length) {
       subheader('Untranslated keys:');
-      untranslated.forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
+      untranslated.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${yellow(key)}: ${cyan(message)}`));
       newLine();
     }
 
     if (added.length) {
       subheader('Added keys:');
-      added.forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
+      added.sort(sortByKey).forEach(({ key, message }) => console.log(`  ${green(key)}: ${cyan(message)}`));
       newLine();
     }
   }

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,0 +1,14 @@
+import stableStringify from 'json-stable-stringify';
+import compareByKey from './compareByKey';
+
+export default function stringify(value, {
+  replacer = null,
+  space = 2,
+  sortKeys = false,
+}) {
+  return (
+    sortKeys
+      ? stableStringify(value, {replacer, space, cmp: compareByKey})
+      : JSON.stringify(value, replacer, space)
+  );
+}

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,14 +1,12 @@
 import stableStringify from 'json-stable-stringify';
 import compareByKey from './compareByKey';
 
-export default function stringify(value, {
+export default (value, {
   replacer = null,
   space = 2,
-  sortKeys = false,
-}) {
-  return (
-    sortKeys
-      ? stableStringify(value, {replacer, space, cmp: compareByKey})
-      : JSON.stringify(value, replacer, space)
-  );
-}
+  sortKeys = true,
+}) => (
+  sortKeys
+    ? stableStringify(value, { replacer, space, cmp: compareByKey })
+    : JSON.stringify(value, replacer, space)
+);


### PR DESCRIPTION
By definition, the order of keys in `JSON.stringify(object)` is undefined. While for general purposes this does not matter a lot, in the case of translated messages it is preferable if the output is at least stable, or better still, alphabetically ordered.

Two reasons:

1. Adding / removing messages will create only a minimal diff (with source control in mind)
2. Messages sorted alphabetically by key are easier to find by hand. Moreover, when using "namespaced" keys like "buttons.close" and "buttons.open", the logical grouping is maintained in the file.

This pull request adds support for [json-stable-stringify](https://github.com/substack/json-stable-stringify), which does exactly what we need here. Please consider releasing an update to include this.

Update: the output of `printResults` is now also sorted (manually).