### PR TITLE
Ignore dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 npm-debug.log
 coverage
+dist


### PR DESCRIPTION
Building creates a "dist" directory which currently wasn't ignored. This simple change adds it to `.gitignore`.