### PR TITLE
Use ES5 by default in translationRunner.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ Create a script in your package.json
 Create a file with your config you can run with the npm script
 ```js
 // translationRunner.js
-import manageTranslations from 'react-intl-translations-manager';
+
+// ES6 version:
+//import manageTranslations from 'react-intl-translations-manager';
+
+// ES5 version:
+var manageTranslations = require('react-intl-translations-manager').default;
 
 manageTranslations({
   messagesDirectory: 'src/translations/extractedMessages',


### PR DESCRIPTION
The `translationRunner.js` example script will not run unless babel is enabled (through a `.babelrc` file for example) with support for ES6. This pull requests adds ES5-style `require` to the script and uses it by default. The original `import` statement is left in a comment for those who like that better.

Note: as I understand it, it is preferred to publish packages ES5-style, even though the source code itself can be ES6 (or anything else). See for example http://blog.xebia.com/publishing-es6-code-to-npm/