### PR TITLE
Default language handling

### DIFF
--- a/example/translationRunner.js
+++ b/example/translationRunner.js
@@ -4,6 +4,7 @@ translationManager({
   messagesDirectory: './src/locales/extractedMessages',
   translationsDirectory: './src/locales/lang/',
   whitelistsDirectory: './src/locales/whitelists/',
-  languages: ['nl'],
+  languages: ['en', 'nl'],
   singleMessagesFile: true,
+  defaultLanguage: 'en',
 });

--- a/src/core.js
+++ b/src/core.js
@@ -11,6 +11,8 @@ export default (languages, hooks) => {
     provideTranslationsFile,
     provideWhitelistFile,
     reportLanguage,
+    defaultLanguage,
+    reportDefaultLanguage,
     afterReporting,
   } = hooks;
 
@@ -24,7 +26,11 @@ export default (languages, hooks) => {
 
   if (typeof beforeReporting === 'function') beforeReporting();
 
-  languages.forEach(lang => {
+  const filteredLanguages = defaultLanguage
+    ? languages.filter(lang => lang !== defaultLanguage)
+    : languages;
+
+  filteredLanguages.forEach(lang => {
     const langResults = provideLangTemplate(lang);
 
     const file = provideTranslationsFile(lang);
@@ -37,6 +43,18 @@ export default (languages, hooks) => {
 
     if (typeof reportLanguage === 'function') reportLanguage(langResults);
   });
+
+  if (typeof defaultLanguage === 'string') {
+    const langResults = provideLangTemplate(defaultLanguage);
+
+    const file = provideTranslationsFile(defaultLanguage);
+
+    if (!file) langResults.noTranslationFile = true;
+
+    langResults.report = getLanguageReport(defaultMessages.messages, file);
+
+    if (typeof reportDefaultLanguage === 'function') reportDefaultLanguage(langResults);
+  }
 
   if (typeof afterReporting === 'function') afterReporting();
 };

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -17,6 +17,7 @@ export default ({
   translationsDirectory,
   whitelistsDirectory = translationsDirectory,
   languages = [],
+  defaultLanguage,
   singleMessagesFile = false,
   detectDuplicateIds = true,
   sortKeys = true,
@@ -31,6 +32,7 @@ export default ({
     space: jsonSpaceIndentation,
     sortKeys,
   };
+
   core(languages, {
     provideExtractedMessages: () => readMessageFiles(messagesDirectory),
     outputSingleFile: combinedFiles => {
@@ -128,6 +130,21 @@ export default ({
           }
           writeFileSync(langResults.whitelistFilepath, stringify([], stringifyOpts));
         }
+      }
+    },
+    defaultLanguage,
+    reportDefaultLanguage: langResults => {
+      if (langResults.report.noTranslationFile) {
+        subheader(```
+          No existing default language file found.
+          A new one is created.
+        ```);
+        writeFileSync(langResults, stringify(langResults.report.fileOutput, stringifyOpts));
+      } else {
+        writeFileSync(
+          langResults.languageFilepath,
+          stringify(langResults.report.fileOutput, stringifyOpts)
+        );
       }
     },
   });


### PR DESCRIPTION
In the current version it isn't recommended to put your default language in the array of languages the manager needs to manage.

With this change you can add your default language to the array of languages, and mark that language as the default one.

This way there will be a language file created for the default language, but no whitelist file. Also this language won't show up in the console logging. It is worth noting that you shouldn't do any changes to this file since these changes should be done in your components themselves.

Pros: Handling your default language is now easier, since you can treat it like any other language
Cons: Your application build will be larger since you will include an extra file with translations, that are actually useless since you can already use the defaultMessages from your components themselves

I'm a little bit in doubt if I should merge this pr, I'm glad to hear your opinion in the comments