### PR TITLE
not consider as duplicated if id and defaultMessage are totally equal

### DIFF
--- a/src/getDefaultMessages.js
+++ b/src/getDefaultMessages.js
@@ -44,7 +44,7 @@ export default files => {
     const duplicateIds = fileAcc.duplicateIds;
     return {
       messages: descriptors.reduce((descAcc, { id, defaultMessage }) => {
-        if (descAcc[id] !== undefined) { duplicateIds.push(id); }
+        if (descAcc[id] !== undefined && descAcc[id] !== defaultMessage) { duplicateIds.push(id); }
 
         return { ...descAcc, [id]: defaultMessage };
       }, fileAcc.messages),


### PR DESCRIPTION
which help find out the real messages that need to create separated ids
