### PR TITLE
Add trailingNewline option

### DIFF
--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -22,6 +22,7 @@ export default ({
   sortKeys = true,
   printers = {},
   jsonSpaceIndentation = 2,
+  jsonTrailingNewline = false
 }) => {
   if (!messagesDirectory || !translationsDirectory) {
     throw new Error('messagesDirectory and translationsDirectory are required');
@@ -29,6 +30,7 @@ export default ({
 
   const stringifyOpts = {
     space: jsonSpaceIndentation,
+    trailingNewline: jsonTrailingNewline,
     sortKeys,
   };
   core(languages, {

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -5,8 +5,10 @@ export default (value, {
   replacer = null,
   space = 2,
   sortKeys = true,
+  trailingNewline = false,
 }) => (
-  sortKeys
+  (sortKeys
     ? stableStringify(value, { replacer, space, cmp: compareByKey })
-    : JSON.stringify(value, replacer, space)
+    : JSON.stringify(value, replacer, space)) +
+  (trailingNewline ? '\n' : '')
 );


### PR DESCRIPTION
Currently all generated JSON files don't contain trailing newlines, this option allows users to enable it.