### PR TITLE
Make the build scripts Windows friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "description": "Manage all translations based on the extracted messages of the babel-plugin-react-intl",
   "main": "./dist/index.js",
   "scripts": {
-    "clean:install": "rm -rf node_modules && npm cache clean && npm install",
-    "test": "NODE_ENV=test mocha --compilers js:babel-core/register --recursive",
+    "clean:install": "rimraf node_modules && npm cache clean && npm install",
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
-    "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover node_modules/mocha/bin/_mocha",
+    "coverage": "cross-env ./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover node_modules/mocha/bin/_mocha",
     "report:coverage": "cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js",
-    "prebuild": "rm -rf dist && mkdir dist",
+    "prebuild": "rimraf dist",
     "build": "babel src --out-dir dist",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "eslint": "eslint --fix ./src ./test"
@@ -49,11 +49,14 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
     "codecov.io": "^0.1.6",
+    "cross-env": "^3.1.3",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
+    "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.0.0",
     "mocha": "^3.0.0",
+    "rimraf": "^2.5.4",
     "semantic-release": "^4.3.5"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-react": "^6.0.0",
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
Currently the build script don't execute properly, because of the usage of Linux commands. 