### PR TITLE
Cleanup of default translationManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,28 +209,10 @@ manageTranslations({
 *This config is only as illustration for all possible options, these arent
 recommended configuration options.
 
-### core
-```js
-core(languages, hooks);
-```
+### CoreMethods
 
-This is the core of the translationManager. It just takes a list of languages
-and an object with all kinds of hooks it will execute when running. Below you
-can find all hooks.
-
-```js
-const hooks = {
-  provideExtractedMessages,
-  outputSingleFile,
-  outputDuplicateKeys,
-  beforeReporting,
-  provideLangTemplate,
-  provideTranslationsFile,
-  provideWhitelistFile,
-  reportLanguage,
-  afterReporting,
-};
-```
+These are the core methods of the translationManager and what purpose they
+serve.
 
 #### provideExtractedMessages
 ```js

--- a/README.md
+++ b/README.md
@@ -33,13 +33,11 @@ now you know what messages you still need to update.
 ## Installing
 
 ```
-npm install --save-dev react-intl-translations-manager
+yarn add --dev react-intl-translations-manager
 ```
 
 ## Setup
 ### Basic
-
-Since you need the `babel-plugin-react-intl` to extract the messages, I'll assume you're using babel in your project.
 
 This is an example of the most basic usage of this plugin, in the API documentation below you can find more options.
 
@@ -47,14 +45,17 @@ Create a script in your package.json
 ```json
 {
   "scripts": {
-    "manage:translations": "babel-node ./translationRunner.js"
+    "manage:translations": "node ./translationRunner.js"
   }
 }
 ```
 Create a file with your config you can run with the npm script
 ```js
 // translationRunner.js
-import manageTranslations from 'react-intl-translations-manager';
+const manageTranslations = require('react-intl-translations-manager');
+
+// es2015 import
+// import manageTranslations from 'react-intl-translations-manager';
 
 manageTranslations({
   messagesDirectory: 'src/translations/extractedMessages',
@@ -68,11 +69,6 @@ Run the translation manager with your new npm script
 ```
 npm run manage:translations
 ```
-
-### Advanced
-
-Build your own translationManager based on the core of this package, or it's
-exposed helper methods.
 
 ## Usage
 
@@ -89,9 +85,13 @@ checking the translations status.
 
 ### manageTranslations
 
-This will maintain all translation files. Based on your config you will get output for duplicate ids, and per specified language you will get the deleted translations, added messages (new messages that need to be translated), and not yet translated messages. It will also maintain a whitelist file per language where you can specify translation keys where the translation is identical to the default message. This way you can avoid untranslated message warnings for these messages.
-
-You can optionally pass a printer object to this method. This way you can override the console logging with your own logging logic. If you want custom file writing logic, it is advised to roll your own translationManager based on the core.
+This will maintain all translation files. Based on your config you will get
+output for duplicate ids, and per specified language you will get the deleted
+translations, added messages (new messages that need to be translated), and not
+yet translated messages. It will also maintain a whitelist file per language
+where you can specify translation keys where the translation is identical to
+the default message. This way you can avoid untranslated message warnings for
+these messages.
 
 #### Config
 
@@ -104,7 +104,8 @@ You can optionally pass a printer object to this method. This way you can overri
   - example: `src/locales/lang`
 - `whitelistsDirectory` (optional, default: `translationsDirectory`)
   - Directory of the whitelist files the translation manager needs to maintain.
-  These files contain the key of translations that have the exact same text in a specific language as the defaultMessage. Specifying this key will suppress
+  These files contain the key of translations that have the exact same text in
+  a specific language as the defaultMessage. Specifying this key will suppress
   `unmaintained translation` warnings.
   - example: `Dashboard` in english is also accepted as a valid translation for
   dutch.
@@ -112,7 +113,8 @@ You can optionally pass a printer object to this method. This way you can overri
   - What languages the translation manager needs to maintain. Specifying no
   languages actually doesn't make sense, but won't break the translationManager
   either.
-  - example: for `['nl', 'fr']` the translation manager will maintain a `nl.json`, `fr.json`, `whitelist_nl.json` and a `whitelist_fr.json` file
+  - example: for `['nl', 'fr']` the translation manager will maintain a
+  `nl.json`, `fr.json`, `whitelist_nl.json` and a `whitelist_fr.json` file
 - `singleMessagesFile` (optional, default: `false`)
   - Option to output a single JSON file containing the aggregate of all extracted messages,
   grouped by the file they were extracted from.
@@ -135,7 +137,8 @@ You can optionally pass a printer object to this method. This way you can overri
   - If you want the translationManager to log duplicate message ids or not
 - `sortKeys` (optional, default: `true`)
   - If you want the translationManager to sort it's output, both json and console output
-- `printers` (optional, default: {})
+- `jsonOptions` (optional, default: { space: 2, trailingNewline: false })
+- `overridePrinters` (optional, default: {})
   - Here you can specify custom logging methods. If not specified a default printer is used.
   - Possible printers to configure:
   ```js
@@ -146,6 +149,65 @@ You can optionally pass a printer object to this method. This way you can overri
       printNoLanguageWhitelistFile: ( lang ) => { console.log(`No existing ${lang} file found. A new one is created.`) },
     };
   ```
+- `overrideCoreMethods` (optional, default: {})
+  - Here you can specify overrides for the core hooks. If not specified, the
+  default methods will be used.
+  - Possible overrides to configure:
+  ```js
+  const overrideCoreMethods = {
+    provideExtractedMessages: () => {},
+    outputSingleFile: () => {},
+    outputDuplicateKeys: () => {},
+    beforeReporting: () => {},
+    provideLangTemplate: () => {},
+    provideTranslationsFile: () => {},
+    provideWhitelistFile: () => {},
+    reportLanguage: () => {},
+    afterReporting: () => {},
+  }
+  ```
+
+#### Fully configured
+
+This is the config with all options applied:
+
+```js
+// import manageTranslations from 'react-intl-translations-manager';
+
+manageTranslations({
+  messagesDirectory: 'src/translations/extractedMessages',
+  translationsDirectory: 'src/translations/locales/',
+  whitelistsDirectory: 'src/translations/locales/whitelists/',
+  languages: ['nl'], // any language you need
+  singleMessagesFile: true,
+  detectDuplicateIds: false,
+  sortKeys: false,
+  jsonOptions: {
+    space: 4,
+    trailingNewline: true,
+  },
+  overridePrinters: {
+    printDuplicateIds: ( duplicateIds ) => { console.log(`You have ${duplicateIds.length } duplicate IDs`) },
+    printLanguageReport: ( report ) => { console.log('Log report for a language') },
+    printNoLanguageFile: ( lang ) => { console.log(`No existing ${lang} translation file found. A new one is created.`) },
+    printNoLanguageWhitelistFile: ( lang ) => { console.log(`No existing ${lang} file found. A new one is created.`) },
+  },
+  overrideCoreMethods: {
+    provideExtractedMessages: () => {},
+    outputSingleFile: () => {},
+    outputDuplicateKeys: () => {},
+    beforeReporting: () => {},
+    provideLangTemplate: () => {},
+    provideTranslationsFile: () => {},
+    provideWhitelistFile: () => {},
+    reportLanguage: () => {},
+    afterReporting: () => {},
+  },
+});
+```
+
+*This config is only as illustration for all possible options, these arent
+recommended configuration options.
 
 ### core
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 export { default } from './manageTranslations';
 
-export { default as core } from './core';
 export { default as readMessageFiles } from './readMessageFiles';
 export { default as createSingleMessagesFile } from './createSingleMessagesFile';
 export { default as getDefaultMessages } from './getDefaultMessages';

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -12,7 +12,6 @@ import stringify from './stringify';
 
 import core from './core';
 
-
 const defaultJSONOptions = {
   space: 2,
   trailingNewline: false,
@@ -28,13 +27,14 @@ export default ({
   sortKeys = true,
   jsonOptions = {},
   overridePrinters = {},
+  overrideCoreMethods = {},
 }) => {
   if (!messagesDirectory || !translationsDirectory) {
     throw new Error('messagesDirectory and translationsDirectory are required');
   }
 
   const defaultPrinters = {
-    printDuplicateIds(duplicateIds) {
+    printDuplicateIds: duplicateIds => {
       header('Duplicate ids:');
       if (duplicateIds.length) {
         duplicateIds.forEach(id => {
@@ -46,30 +46,30 @@ export default ({
       footer();
     },
 
-    printLanguageReport(langResults) {
+    printLanguageReport: langResults => {
       header(`Maintaining ${yellow(langResults.languageFilename)}:`);
       printResults({ ...langResults.report, sortKeys });
-    }
+    },
 
-   printNoLanguageFile(langResults) {
-     subheader(`
+    printNoLanguageFile: langResults => {
+      subheader(`
         No existing ${langResults.languageFilename} translation file found.
         A new one is created.
       `);
-    }
+    },
 
-    printNoLanguageWhitelistFile(langResults) {
+    printNoLanguageWhitelistFile: langResults => {
       subheader(```
         No existing ${langResults} file found.
         A new one is created.
       ```);
-    }
+    },
   };
 
   const printers = {
     ...defaultPrinters,
     ...overridePrinters,
-  }
+  };
 
   const stringifyOpts = {
     ...defaultJSONOptions,
@@ -77,7 +77,7 @@ export default ({
     sortKeys,
   };
 
-  core(languages, {
+  const defaultCoreMethods = {
     provideExtractedMessages: () => readMessageFiles(messagesDirectory),
 
     outputSingleFile: combinedFiles => {
@@ -152,5 +152,12 @@ export default ({
         }
       }
     },
+
+    afterReporting: () => {},
+  };
+
+  core(languages, {
+    ...defaultCoreMethods,
+    ...overrideCoreMethods,
   });
 };

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -12,6 +12,12 @@ import stringify from './stringify';
 
 import core from './core';
 
+
+const defaultJSONOptions = {
+  space: 2,
+  trailingNewline: false,
+};
+
 export default ({
   messagesDirectory,
   translationsDirectory,
@@ -21,18 +27,18 @@ export default ({
   detectDuplicateIds = true,
   sortKeys = true,
   printers = {},
-  jsonSpaceIndentation = 2,
-  jsonTrailingNewline = false,
+  jsonOptions = {},
 }) => {
   if (!messagesDirectory || !translationsDirectory) {
     throw new Error('messagesDirectory and translationsDirectory are required');
   }
 
   const stringifyOpts = {
-    space: jsonSpaceIndentation,
-    trailingNewline: jsonTrailingNewline,
+    ...defaultJSONOptions,
+    ...jsonOptions,
     sortKeys,
   };
+
   core(languages, {
     provideExtractedMessages: () => readMessageFiles(messagesDirectory),
     outputSingleFile: combinedFiles => {


### PR DESCRIPTION
- [x] cleanup of json file options
- [x] cleanup of internal printer logic, to be more in sync with exposed printer overrides
- [x] add ability to override core methods without having to use `core` itself