### PR TITLE
Add regular expression support to whitelists

### DIFF
--- a/src/getLanguageReport.js
+++ b/src/getLanguageReport.js
@@ -43,14 +43,16 @@ export default (defaultMessages, languageMessages = {}, languageWhitelist = []) 
       result.fileOutput[key] = oldMessage;
 
       if (oldMessage === defaultMessage) {
-        if (languageWhitelist.indexOf(key) === -1) {
-          result.untranslated.push({
-            key,
-            message: defaultMessage,
-          });
-        } else {
-          result.whitelistOutput.push(key);
+        for (const entry of languageWhitelist) {
+          if (entry instanceof RegExp ? entry.test(key) : key === entry) {
+            result.whitelistOutput.push(key);
+            return;
+          }
         }
+        result.untranslated.push({
+          key,
+          message: defaultMessage,
+        });
       }
     } else {
       result.fileOutput[key] = defaultMessage;

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -125,7 +125,13 @@ export default ({
     provideWhitelistFile: lang => {
       const filePath = Path.join(whitelistsDirectory, `whitelist_${lang}.json`);
       const jsonFile = readFile(filePath);
-      return jsonFile ? JSON.parse(jsonFile) : undefined;
+      const whitelist =  jsonFile ? JSON.parse(jsonFile) : undefined;
+      return whitelist.map((entry) => {
+        if (typeof entry !== 'string' && entry.length) {
+          return new RegExp(entry[0], entry[1] || '');
+        }
+        return entry;
+      });
     },
 
     reportLanguage: langResults => {

--- a/test/getLanguageReport.test.js
+++ b/test/getLanguageReport.test.js
@@ -143,4 +143,26 @@ describe('getLanguageReport', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should give back a report with whitelisted messages', () => {
+    const actual = getLanguageReport({
+      test_message: 'This is a test message',
+    }, {
+      'test_message': 'This is a test message'
+    }, [
+      new RegExp('test', 'g')
+    ]);
+
+    const expected = {
+      ...getCleanReport(),
+      fileOutput: {
+        'test_message': 'This is a test message'
+      },
+      whitelistOutput: [
+        'test_message',
+      ],
+    };
+
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Example whitelist:
```json
[
    "whitelisted_message",
    ["whitelist", "g"]
]
```

The second line will get parsed to a regular expression with the first array entry as expression and the second array entry as flags.