### PR TITLE
Minor note changes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yarn add --dev react-intl-translations-manager
 or 
 
 ```
-npm i react-intl-translations-manager -D
+npm i --save-dev react-intl-translations-manager
 ```
 
 ## Setup
@@ -118,7 +118,7 @@ these messages.
 - `languages` (optional, default: `[]`)
   - What languages the translation manager needs to maintain. Specifying no
   languages actually doesn't make sense, but won't break the translationManager
-  either. (Do not include the default language, react-intl will automatically include it.)
+  either. (Please do not include the default language, react-intl will automatically include it.)
   - example: for `['nl', 'fr']` the translation manager will maintain a
   `nl.json`, `fr.json`, `whitelist_nl.json` and a `whitelist_fr.json` file
 - `singleMessagesFile` (optional, default: `false`)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ now you know what messages you still need to update.
 yarn add --dev react-intl-translations-manager
 ```
 
+or 
+
+```
+npm i react-intl-translations-manager -D
+```
+
 ## Setup
 ### Basic
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ these messages.
 - `languages` (optional, default: `[]`)
   - What languages the translation manager needs to maintain. Specifying no
   languages actually doesn't make sense, but won't break the translationManager
-  either.
+  either. (Do not include the default language, react-intl will automatically include it.)
   - example: for `['nl', 'fr']` the translation manager will maintain a
   `nl.json`, `fr.json`, `whitelist_nl.json` and a `whitelist_fr.json` file
 - `singleMessagesFile` (optional, default: `false`)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create a script in your package.json
 Create a file with your config you can run with the npm script
 ```js
 // translationRunner.js
-const manageTranslations = require('react-intl-translations-manager');
+const manageTranslations = require('react-intl-translations-manager').default;
 
 // es2015 import
 // import manageTranslations from 'react-intl-translations-manager';


### PR DESCRIPTION
Three minor changes:

1. added line about NPM install. originally I wasn't sure I could use the package because I've never worked with Yarn before. I added a quick note to help others understand.
2. ES5 requires .default to use the package. After I installed the package through npm I tried to use it via Node JS require. I received an error stating 'not a function'. I added a `.default` to the package and it worked.
3. Added not about managing the default language. I didn't realize react-intl included the default language by default so I thought I needed to manage it.