### PR TITLE
Fix the path to translation and whitelist files so they can easily be renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ The following keys are restricted and will be overridden by the core: `report`, 
 
 #### provideTranslationsFile
 ```js
-const translationsFile = provideTranslationsFile(lang);
+const translationsFile = provideTranslationsFile(languageResults);
 ```
 
 Here you should return the translations for the specified language. This must be an object with the message id and message in a key value format.
@@ -284,7 +284,7 @@ const translationsFile = {
 
 #### provideWhitelistFile
 ```js
-const whitelistFile = provideWhitelistFile(lang);
+const whitelistFile = provideWhitelistFile(languageResults);
 ```
 
 Here you should return the whitelisted messsage ids for the specified language. This must be an array of strings.

--- a/src/core.js
+++ b/src/core.js
@@ -27,8 +27,8 @@ export default (languages, hooks) => {
   languages.forEach(lang => {
     const langResults = provideLangTemplate(lang);
 
-    const file = provideTranslationsFile(lang);
-    const whitelistFile = provideWhitelistFile(lang);
+    const file = provideTranslationsFile(langResults);
+    const whitelistFile = provideWhitelistFile(langResults);
 
     if (!file) langResults.noTranslationFile = true;
     if (!whitelistFile) langResults.noWhitelistFile = true;

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -116,15 +116,13 @@ export default ({
       };
     },
 
-    provideTranslationsFile: lang => {
-      const filePath = Path.join(translationsDirectory, `${lang}.json`);
-      const jsonFile = readFile(filePath);
+    provideTranslationsFile: langResults => {
+      const jsonFile = readFile(langResults.languageFilepath);
       return jsonFile ? JSON.parse(jsonFile) : undefined;
     },
 
-    provideWhitelistFile: lang => {
-      const filePath = Path.join(whitelistsDirectory, `whitelist_${lang}.json`);
-      const jsonFile = readFile(filePath);
+    provideWhitelistFile: langResults => {
+      const jsonFile = readFile(langResults.whitelistFilepath);
       return jsonFile ? JSON.parse(jsonFile) : undefined;
     },
 


### PR DESCRIPTION
Currently `provideTranslationsFile` and `provideWhitelistFile` ignore the output of `provideLangTemplate`. This means that if the whitelists filename returned by `provideLangTemplate` is `en.json` then `provideWhitelistFile` will look for the wrong file which results in the whitelists file being overwritten every time the `manageTranslations` is run.

This PR changes that behaviour by passing the output of `provideLangTemplate` to `provideTranslationsFile` and `provideWhitelistFile`.