### PR TITLE
Add coreOpt to allow an empty message description be used as message instead of defaultMessage.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,7 +1,7 @@
 import getDefaultMessages from './getDefaultMessages';
 import getLanguageReport from './getLanguageReport';
 
-export default (languages, hooks) => {
+export default (languages, hooks, coreOpt) => {
   const {
     provideExtractedMessages,
     outputSingleFile,
@@ -11,7 +11,7 @@ export default (languages, hooks) => {
     provideTranslationsFile,
     provideWhitelistFile,
     reportLanguage,
-    afterReporting
+    afterReporting,
   } = hooks;
 
   const extractedMessages = provideExtractedMessages();
@@ -40,7 +40,8 @@ export default (languages, hooks) => {
     langResults.report = getLanguageReport(
       defaultMessages.messages,
       file,
-      whitelistFile
+      whitelistFile,
+      coreOpt,
     );
 
     if (typeof reportLanguage === 'function') reportLanguage(langResults);

--- a/src/getLanguageReport.js
+++ b/src/getLanguageReport.js
@@ -33,7 +33,8 @@ export const getCleanReport = () => ({
 export default (
   defaultMessages,
   languageMessages = {},
-  languageWhitelist = []
+  languageWhitelist = [],
+  coreOpt = {},
 ) => {
   const result = getCleanReport();
 
@@ -43,7 +44,7 @@ export default (
     const oldMessage = languageMessages[key];
     const defaultMessage = defaultMessages[key];
 
-    if (oldMessage) {
+    if ((coreOpt.enableEmptyValue && oldMessage === '') || oldMessage) {
       result.fileOutput[key] = oldMessage;
 
       if (oldMessage === defaultMessage) {

--- a/src/manageTranslations.js
+++ b/src/manageTranslations.js
@@ -27,7 +27,8 @@ export default ({
   sortKeys = true,
   jsonOptions = {},
   overridePrinters = {},
-  overrideCoreMethods = {}
+  overrideCoreMethods = {},
+  coreOpt = {},
 }) => {
   if (!messagesDirectory || !translationsDirectory) {
     throw new Error('messagesDirectory and translationsDirectory are required');
@@ -173,6 +174,7 @@ export default ({
 
   core(languages, {
     ...defaultCoreMethods,
-    ...overrideCoreMethods
+    ...overrideCoreMethods,
+    coreOpt,
   });
 };

--- a/test/getLanguageReport.test.js
+++ b/test/getLanguageReport.test.js
@@ -57,6 +57,31 @@ describe('getLanguageReport', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should give back a report with fileout pair: test_message and empty string', () => {
+    const actual = getLanguageReport(
+      {
+        test_message: 'This is a test message'
+      },
+      {
+        test_message: '',
+      },
+      [],
+      {
+        enableEmptyValue: true,
+      }
+    );
+
+    const expected = {
+      ...getCleanReport(),
+      added: [],
+      fileOutput: {
+        test_message: ''
+      }
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
   it('should give back a report with untranslated messages', () => {
     const actual = getLanguageReport(
       {


### PR DESCRIPTION
For some use cases, the languageMessages has empty values that should be persisted, ignoring the defaultMessage.
For this propose, a new parameter named: `coreOpt` was added, containing a property names: `enableEmptyValue` , when true the empty value is persisted.

Tests: Please check the test named: `should give back a report with fileout pair: test_message and empty string`.

This is a minor change, and do not break the code that already exist.